### PR TITLE
Catch and filter pyspark exceptions correctly in Codelab

### DIFF
--- a/codelabs/spark-bigquery/counts_by_subreddit.py
+++ b/codelabs/spark-bigquery/counts_by_subreddit.py
@@ -57,8 +57,11 @@ for year in years:
             table_df = (spark.read.format('bigquery').option('table', table)
                         .load())
             tables_read.append(table)
-        except Py4JJavaError:
-            continue
+        except Py4JJavaError as e:
+            if f"Table {table} not found" in str(e):
+                continue
+            else:
+                raise
 
         # We perform a group-by on subreddit, aggregating by the count and then
         # unioning the output to our base dataframe


### PR DESCRIPTION
While trying out this codelab I observed that valid Py4JJavaErrors were being concealed, when we really just want to ignore table not found exceptions. This issue can cause users to incorrectly infer that required tables do not exist in BigQuery, when the problem could be something entirely different.

Changing this to help users debug the issues better.

(Found this issue while working on https://github.com/GoogleCloudDataproc/cloud-dataproc/issues/139)